### PR TITLE
Drop Python 2.6 skip

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,6 @@ source:
 build:
   number: 1000
   script: python setup.py install --single-version-externally-managed --record record.txt
-  skip: True  # [py26]
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes https://github.com/conda-forge/zeep-feedstock/issues/7:

> There is a Python 2.6 skip in the recipe. However Python 2.6 is not being built or supported in conda-forge. So this can safely be dropped from the recipe.



<!--
Please add any other relevant info below:
-->
